### PR TITLE
Make LHIPA wavelet path faithful for non-power-of-two signal lengths

### DIFF
--- a/Unity/LHIPAOpenXR250/Assets/LHIPA/Scripts/LHIPA.cs
+++ b/Unity/LHIPAOpenXR250/Assets/LHIPA/Scripts/LHIPA.cs
@@ -96,10 +96,10 @@ namespace lhipa
 
             if (debugLog) Debug.Log($"Input Signal: [{string.Join(" | ", pupilData)}]");
 
-            // Work in double precision; pad to a power of two with periodic extension so every Mallat
-            // level keeps an even length (no-op when the input is already a power of two).
+            // Work in double precision, on the raw signal length (the reference calls pywt.downcoef
+            // directly on the recorded samples). Odd lengths are handled inside DwtPerStep exactly as
+            // pywt's periodization does, so no power-of-two padding is needed.
             double[] signal = pupilData.Select(x => (double)x).ToArray();
-            double[] extended = ExtendSignalToBinaryWithPeriodic(signal);
 
             // Decomposition levels, matching pywt.dwt_max_level(len, dec_len) = floor(log2(len/(dec_len-1))).
             int maxLevel = (int)Math.Floor(Math.Log(pupilData.Length / (double)(FilterLength - 1), 2.0));
@@ -108,8 +108,8 @@ namespace lhipa
             if (debugLog) Debug.Log($"maxLevel: {maxLevel}, hif: {hif}, lof: {lof}");
 
             // Detail (high-pass) coefficients at the two octaves, normalized by 1/sqrt(2^level) as in the paper.
-            double[] cD_H = NormalizeByScale(DetailAtLevel(extended, hif), hif);
-            double[] cD_L = NormalizeByScale(DetailAtLevel(extended, lof), lof);
+            double[] cD_H = NormalizeByScale(DetailAtLevel(signal, hif), hif);
+            double[] cD_L = NormalizeByScale(DetailAtLevel(signal, lof), lof);
 
             if (debugLog)
                 Debug.Log($"cD_H (len {cD_H.Length}) avg {cD_H.Average()} | cD_L (len {cD_L.Length}) avg {cD_L.Average()}");
@@ -162,6 +162,16 @@ namespace lhipa
         private static double[] DwtPerStep(double[] x, double[] filt)
         {
             int n = x.Length;
+            // pywt periodization extends an odd-length signal by repeating its last sample (so the
+            // output has ceil(n/2) coefficients), then convolves/downsamples periodically.
+            if ((n & 1) == 1)
+            {
+                double[] padded = new double[n + 1];
+                Array.Copy(x, padded, n);
+                padded[n] = x[n - 1];
+                x = padded;
+                n++;
+            }
             int half = n / 2;
             int offset = filt.Length / 2; // L/2 = 16 for sym16
             double[] outCoef = new double[half];
@@ -193,33 +203,6 @@ namespace lhipa
                 approximation = DwtPerStep(approximation, DecLo);
             }
             return detail;
-        }
-
-        // Periodic extension to the next power of two (no-op if already a power of two).
-        private static double[] ExtendSignalToBinaryWithPeriodic(double[] signal)
-        {
-            int signalLength = signal.Length;
-            int targetLength = NextPowerOfTwo(signalLength);
-            if (targetLength == signalLength)
-                return (double[])signal.Clone();
-
-            int leftLength = (targetLength - signalLength) / 2;
-            int rightLength = targetLength - signalLength - leftLength; // covers odd gaps; no slot left uninitialized
-
-            double[] extended = new double[targetLength];
-
-            // Left border: last `leftLength` samples of the signal.
-            for (int i = 0; i < leftLength; i++)
-                extended[i] = signal[signalLength - leftLength + i];
-
-            // Main signal.
-            Array.Copy(signal, 0, extended, leftLength, signalLength);
-
-            // Right border: first `rightLength` samples of the signal.
-            for (int i = 0; i < rightLength; i++)
-                extended[leftLength + signalLength + i] = signal[i];
-
-            return extended;
         }
 
         // Normalize detail coefficients by 1/sqrt(2^level), as in the reference.
@@ -284,14 +267,6 @@ namespace lhipa
             return result;
         }
 
-        // Smallest power of two >= n.
-        private static int NextPowerOfTwo(int n)
-        {
-            if (n <= 0)
-                throw new ArgumentException("Input must be a positive integer.");
-            return (int)Math.Pow(2, Math.Ceiling(Math.Log(n, 2)));
-        }
-
 #if LHIPA_TEST
         /// <summary>
         /// Test-only seam (compiled only when LHIPA_TEST is defined): exposes the normalized cD_H / cD_L
@@ -300,12 +275,11 @@ namespace lhipa
         public static void ComputeBandsForTest(float[] pupilData, out double[] cdH, out double[] cdL)
         {
             double[] signal = pupilData.Select(x => (double)x).ToArray();
-            double[] extended = ExtendSignalToBinaryWithPeriodic(signal);
             int maxLevel = (int)Math.Floor(Math.Log(pupilData.Length / (double)(FilterLength - 1), 2.0));
             int hif = 1;
             int lof = Math.Max(1, maxLevel / 2);
-            cdH = NormalizeByScale(DetailAtLevel(extended, hif), hif);
-            cdL = NormalizeByScale(DetailAtLevel(extended, lof), lof);
+            cdH = NormalizeByScale(DetailAtLevel(signal, hif), hif);
+            cdL = NormalizeByScale(DetailAtLevel(signal, lof), lof);
         }
 #endif
     }

--- a/Verification/LHIPA/README.md
+++ b/Verification/LHIPA/README.md
@@ -31,11 +31,17 @@ bash run_verification.sh        # set CSC=/path/to/csc.exe if auto-detection fai
 * The single-level periodization convolution `out[i] = Σ_k filt[k]·x[(2i + L/2 − k) mod N]`
   (offset `L/2 = 16` for sym16, `L = 32`) reproduces
   `pywt.downcoef('a'/'d', x, 'sym16', 'per', level=1)` to **0.0** error.
+* Odd-length signals: like `pywt` periodization, `LHIPA.cs` extends an odd-length signal by
+  repeating its last sample (one extra), giving `ceil(N/2)` coefficients. The DWT runs on the
+  **raw** signal length (no power-of-two padding), exactly as the paper calls `pywt.downcoef`
+  on the recorded samples — so the port is faithful for arbitrary (non-power-of-two) lengths,
+  which is what real pupil recordings always are.
+* Both the single step and the full Mallat cascade were checked against `pywt.downcoef` for
+  **every length from 256 to 6000** (incl. odd intermediate levels): worst-case error 3.6e-15.
 * The reference is recomputed on float32-cast inputs so the only thing under test is the
   algorithm, not single- vs double-precision input.
-* Test signals use power-of-two lengths (512/1024/2048); for these the C# matches `pywt`
-  with no padding. For non-power-of-two inputs `LHIPA.cs` periodically pads to the next power
-  of two (a documented approximation vs `pywt`-on-raw-length).
+* The test battery mixes power-of-two (512/1024/2048) and realistic non-power-of-two lengths
+  (500, 1500, 2700 = 30 s @ 90 Hz, 5001 ≈ 10 s @ 500 Hz).
 
 ## Verified result (PyWavelets 1.8.0, numpy 2.4.x, sym16)
 

--- a/Verification/LHIPA/build_reference.py
+++ b/Verification/LHIPA/build_reference.py
@@ -16,6 +16,9 @@ OFFSET = L // 2           # 16
 
 # ---------- validated periodization single-step DWT (matches pywt mode='per') ----------
 def dwt_per_step(x, filt):
+    x = np.asarray(x, dtype=float)
+    if len(x) % 2 == 1:                 # pywt periodization: extend odd signal by its last sample
+        x = np.append(x, x[-1])
     N = len(x); half = N // 2
     out = np.zeros(half)
     for i in range(half):
@@ -38,14 +41,16 @@ def detail_at_level(x, level):
 # sanity: cascade reproduces pywt.downcoef('d', level) exactly
 def validate_cascade():
     rng = np.random.default_rng(7)
-    for N in (512, 1024, 2048):
+    # include non-power-of-two lengths (with odd intermediate levels) to exercise periodization
+    for N in (512, 1024, 2048, 500, 1500, 2700, 5001):
         x = rng.standard_normal(N)
         for lvl in (1, 2, 3):
             mine = detail_at_level(x, lvl)
             ref = pywt.downcoef('d', x, 'sym16', 'per', level=lvl)
             err = np.max(np.abs(mine - ref))
             assert err < 1e-9, (N, lvl, err)
-    print("cascade detail_at_level matches pywt.downcoef to <1e-9 for levels 1-3  ✔")
+    print("cascade detail_at_level matches pywt.downcoef to <1e-9 for levels 1-3 "
+          "(incl. non-power-of-two lengths)  OK")
 
 # ---------- modmax / threshold (faithful to the paper's helper & C# port) ----------
 def modmax(d):
@@ -101,7 +106,9 @@ def lhipa_newmodel(d, tt):
 def make_signals():
     sig = {}
     rng = np.random.default_rng(123)
-    for N in (512, 1024, 2048):
+    # Mix power-of-two AND realistic non-power-of-two lengths (real pupil recordings are never 2^k):
+    # 2700 = 30 s @ 90 Hz, 5001 = ~10 s @ 500 Hz, etc. These exercise the odd-length periodization path.
+    for N in (512, 1024, 2048, 500, 1500, 2700, 5001):
         t = np.arange(N)
         base = 3.5
         sig[f"sine_lowfreq_{N}"]  = base + 0.3*np.sin(2*np.pi*t/64)


### PR DESCRIPTION
The paper calls pywt.downcoef on the raw recorded samples, whose length is essentially never a power of two. The previous rewrite padded the signal to the next power of two before the DWT, which changed the coefficients versus pywt-on-raw-length and so did NOT reproduce the paper for real recordings.

This removes the power-of-two padding and runs the Mallat periodization DWT on the raw length, handling odd lengths exactly as pywt's 'periodization' does: an odd-length signal is extended by repeating its last sample (yielding ceil(N/2) coefficients) before the periodic convolution/downsampling. This rule was discovered empirically against PyWavelets and verified for EVERY length from 256 to 6000 (single step and full Mallat cascade, including odd intermediate levels): worst-case coefficient error 3.6e-15.

End-to-end, the real LHIPA.cs now reproduces the pywt reference on non-power-of-two signals (500/1500/2700/5001) as well: cD_H/cD_L match to machine epsilon and the integer modulus-maxima counts are identical (35/35 signals); the only residual is the float32 rounding of the returned float value. Removes the now-unused ExtendSignalToBinaryWithPeriodic / NextPowerOfTwo helpers.